### PR TITLE
use env to run ruby for ruby version management compatability

### DIFF
--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 require 'rbconfig'
 


### PR DESCRIPTION
Solves issue where using `/usr/bin/ruby` uses system ruby of 1.8.7 and when bundler is loaded, `Gemfile` cannot be parsed if it uses ruby 1.9+ hash syntax.
