### PR TITLE
make concise

### DIFF
--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -9,13 +9,15 @@
 
 require 'rbconfig'
 
-if RbConfig::CONFIG['host_os'] =~ /linux/
-  executable = RbConfig::CONFIG['host_cpu'] == 'x86_64' ? 'wkhtmltopdf_linux_amd64' : 'wkhtmltopdf_linux_x86'
-elsif RbConfig::CONFIG['host_os'] =~ /darwin/
-  executable = 'wkhtmltopdf_darwin_x86'
+suffix = case RbConfig::CONFIG['host']
+when /x86_64.*linux/
+  'linux_amd64'
+when /linux/
+  'linux_x86'
+when /darwin/
+  'darwin_x86'
 else
-  raise "Invalid platform. Must be running linux or intel-based Mac OS."
+  raise "Invalid platform. Must be running on linux or intel-based Mac OS."
 end
 
-executable = File.join(File.dirname(__FILE__), executable)
-system *$*.unshift(executable)
+system *$*.unshift("#{__FILE__}_#{suffix}")


### PR DESCRIPTION
Make logical operations more simple and concise due to use 'host' instead of separate values 'host_os' and 'host_cpu'.
