### PR TITLE
Don't require `rake` for ruby 2.3.x compatibility

### DIFF
--- a/wkhtmltopdf-binary.gemspec
+++ b/wkhtmltopdf-binary.gemspec
@@ -1,5 +1,4 @@
 # coding: utf-8
-require 'rake'
 
 Gem::Specification.new do |s|
   s.name = "wkhtmltopdf-binary"


### PR DESCRIPTION
Under ruby 2.3.x bundler cannot install this gem as needed because the `require 'rake'` at the beginning of the `.gemspec` file breaks the installation process.