### PR TITLE
Use `exec` instead of `system`

### DIFF
--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -20,4 +20,4 @@ else
   raise "Invalid platform. Must be running on linux or intel-based Mac OS."
 end
 
-system *$*.unshift("#{__FILE__}_#{suffix}")
+exec *$*.unshift("#{__FILE__}_#{suffix}")


### PR DESCRIPTION
This replaces the current process with wkhtmltopdf instead of running it in a subprocess. This way, when the process is killed, wkhtmltopdf won’t keep running as an orphan.
