### PR TITLE
JRuby compatibility

### DIFF
--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -9,11 +9,9 @@
 
 require 'rbconfig'
 
-suffix = case RbConfig::CONFIG['host']
-when /x86_64.*linux/
-  'linux_amd64'
+suffix = case RbConfig::CONFIG['host_os']
 when /linux/
-  'linux_x86'
+  (RbConfig::CONFIG['host_cpu'] == 'x86_64') ? 'linux_amd64' : 'linux_x86'
 when /darwin/
   'darwin_x86'
 else


### PR DESCRIPTION
JRuby compatibility is now restored. It was previously broken by commit 41bf695 (https://github.com/zakird/wkhtmltopdf_binary_gem/commit/41bf695f32ebc09effde32837ca8d5c9e14602bc).
The problem was verified in but not limited to
jruby-1.7.4
jruby-1.7.13
jruby-1.7.16
jruby-1.7.16.1
jruby-1.7.19

The essence is that RbConfig::CONFIG['host'] returns nil in JRuby thus causing the Regex in the 'case' expression to fail and always raise an exception.

It is fixed by no longer relying on RbConfig::CONFIG['host'] but on RbConfig::CONFIG['host_os'] and RbConfig::CONFIG['host_cpu'] instead while being as 'concise' as possible.