### PR TITLE
Added RaspberryPi 3 support by adding binary and detection for Linux armhf

### DIFF
--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -11,7 +11,16 @@ require 'rbconfig'
 
 suffix = case RbConfig::CONFIG['host_os']
 when /linux/
-  (RbConfig::CONFIG['host_cpu'] == 'x86_64') ? 'linux_amd64' : 'linux_x86'
+  host_cpu = RbConfig::CONFIG['host_cpu']
+  if host_cpu == 'arm'
+    if `readelf -A /proc/self/exe | grep Tag_ABI_VFP_args` == "  Tag_ABI_VFP_args: VFP registers\n"
+      'linux_armhf'
+    else
+      raise "Unknown ARM processor."
+    end
+  else
+    (host_cpu == 'x86_64') ? 'linux_amd64' : 'linux_x86'
+  end
 when /darwin/
   'darwin_x86'
 else


### PR DESCRIPTION
The wkhtmltopdf_linux_armhf binary version is 0.12.3-dev (with patched QT).

The binary was downloaded from here: https://github.com/wkhtmltopdf/wkhtmltopdf/files/720814/wkhtmltopdf.zip

The link for the binary was from the discussion here:
https://github.com/wkhtmltopdf/wkhtmltopdf/issues/1868

Tested on RaspberryPi 3 running Raspbian 8.0 with JRuby 1.7.19, Java 1.8.0_65.

Version bump recommended.