### PR TITLE
#43: Add a rake task to compress binaries with UPX

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,20 @@
 require 'rubygems'
 require 'rubygems/package_task'
 
+task :compress_binaries do
+  Dir.glob(File.join(__dir__, 'bin/', '*{x86,amd64}')).each do |path|
+    sh "upx", "-t", path do |success|
+      if success
+        puts "#{path} already compressed, skipping"
+      else
+        sh "upx", path
+      end
+    end
+  end
+end
+
+task gem: :compress_binaries
+  
 spec = eval(File.new("wkhtmltopdf-binary.gemspec").readlines.join("\n"))
 Gem::PackageTask.new(spec) do |pkg|
   pkg.need_tar = true


### PR DESCRIPTION
It's been added to the gem package task's prerequisites, so the binaries will be changed locally and then packed into the gem. This PR doesn't contain the packed binaries themselves. My idea is that we should grab and store the upstream binaries untouched, but ship the compact versions with this gem.

Gemfile size before packing: 171MB
After packing: 45MB

Also, the task is safe to run multiple times - already-compressed files will be detected and skipped (using `upx -t`).