### PR TITLE
Fix: Elementary OS distro

### DIFF
--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -14,6 +14,11 @@ suffix = case RbConfig::CONFIG['host_os']
          when /linux/
            os = `. /etc/os-release 2> /dev/null && echo ${ID}_${VERSION_ID}`.strip
 
+           # Elementary OS is based in Ubuntu.
+           if os.include?('elementary')
+             os = 'ubuntu_18.04'
+           end
+         
            # CentOS 6 doesn't have `/etc/os-release`.
            if os.empty? && File.read('/etc/centos-release').start_with?('CentOS release 6')
              os = 'centos_6'


### PR DESCRIPTION
Use latest ubuntu release binary to elementary os distro, because it is based in Ubuntu