### PR TITLE
Deepin binary check

### DIFF
--- a/.docker/Dockerfile-deepin
+++ b/.docker/Dockerfile-deepin
@@ -1,0 +1,8 @@
+FROM deepin/deepin-core:latest
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update
+RUN apt-get install -y ruby libjpeg8 libxrender1 libfontconfig1
+
+CMD /root/wkhtmltopdf_binary_gem/bin/wkhtmltopdf --version

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@ require 'rubygems/package_task'
 require 'rake/testtask'
 
 spec = eval(File.new("wkhtmltopdf-binary.gemspec").readlines.join("\n"))
+
 Gem::PackageTask.new(spec) do |pkg|
   pkg.need_tar = true
 end

--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -24,6 +24,9 @@ suffix = case RbConfig::CONFIG['host_os']
              os = 'centos_6'
            end
 
+           # Deepin fallback
+           os = 'debian_9' if /deepin/.match?(os)
+
            architecture = RbConfig::CONFIG['host_cpu'] == 'x86_64' ? 'amd64' : 'i386'
 
            "#{os}_#{architecture}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,3 +63,10 @@ services:
       dockerfile: .docker/Dockerfile-centos_8
     volumes:
       - .:/root/wkhtmltopdf_binary_gem
+
+  deepin:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile-deepin
+    volumes:
+      - .:/root/wkhtmltopdf_binary_gem

--- a/test/test_with_docker.rb
+++ b/test/test_with_docker.rb
@@ -13,7 +13,7 @@ class WithDockerTest < Minitest::Test
   def test_centos_7
     test with: 'centos_7'
   end
-  
+
   def test_centos_8
     test with: 'centos_8'
   end


### PR DESCRIPTION
Hi everyone!

This PR will add check for Deepin OS for check what binary will be loaded. I see the work-around on this issue https://github.com/zakird/wkhtmltopdf_binary_gem/issues/62 but this is not totally satisfactory...

I'm try do test for a deepin image but I does not found a good Docker image. Can anyone help me with this test?

Thanks!

---
### Context
```bash
cat /etc/os-release

PRETTY_NAME="Deepin 15"
NAME="Deepin"
VERSION_ID="15.11"
VERSION="15.11"
ID=deepin
HOME_URL="https://www.deepin.org/"
BUG_REPORT_URL="http://feedback.deepin.org/feedback/"
```

I'm work with deepin on my laptop.
The Deepin is OS based on debian (some versions on unstable and other on stable):
![image](https://user-images.githubusercontent.com/4596160/80855739-063e3580-8c1a-11ea-981e-297feca5825d.png)
_Deepin version X Debian Version table (by: https://en.wikipedia.org/wiki/Deepin)_
