### PR TITLE
Add support for Ubuntu 20.04

### DIFF
--- a/.docker/Dockerfile-ubuntu_20.04
+++ b/.docker/Dockerfile-ubuntu_20.04
@@ -1,0 +1,8 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update
+RUN apt-get install -y ruby libjpeg8 libxrender1 libfontconfig1
+
+CMD /root/wkhtmltopdf_binary_gem/bin/wkhtmltopdf --version

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ bin/wkhtmltopdf_macos_carbon
 bin/wkhtmltopdf_ubuntu_14.04_amd64
 bin/wkhtmltopdf_ubuntu_16.04_amd64
 bin/wkhtmltopdf_ubuntu_18.04_amd64
+bin/wkhtmltopdf_ubuntu_20.04_amd64
 bin/wkhtmltopdf_centos_6_i386
 bin/wkhtmltopdf_centos_7_i386
 bin/wkhtmltopdf_debian_8_i386

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 0.12.6
+Add support for Ubuntu Focal Fossa (20.04)
+
 # 0.12.5.4
 Remove accidental unpacked binary
 

--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -45,7 +45,7 @@ if File.exist?("#{binary}.gz") && !File.exist?(binary)
 end
 
 unless File.exist? binary
-  raise 'Invalid platform, must be running on Ubuntu 14.04/16.04/18.04 ' \
+  raise 'Invalid platform, must be running on Ubuntu 14.04/16.04/18.04/20.04 ' \
         'CentOS 6/7/8, Debian 8/9/10, or intel-based macOS ' \
         "(missing binary: #{binary})."
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,13 @@ services:
     volumes:
       - .:/root/wkhtmltopdf_binary_gem
 
+  ubuntu_20.04:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile-ubuntu_20.04
+    volumes:
+      - .:/root/wkhtmltopdf_binary_gem
+
   debian_8:
     build:
       context: .

--- a/test/test_with_docker.rb
+++ b/test/test_with_docker.rb
@@ -42,6 +42,10 @@ class WithDockerTest < Minitest::Test
     test with: 'ubuntu_18.04'
   end
 
+  def test_with_ubuntu_20
+    test with: 'ubuntu_20.04'
+  end
+
   def test_with_macos
     assert_equal `bin/wkhtmltopdf --version`.strip, 'wkhtmltopdf 0.12.5 (with patched qt)'
   end

--- a/wkhtmltopdf-binary.gemspec
+++ b/wkhtmltopdf-binary.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "wkhtmltopdf-binary"
-  s.version = "0.12.5.4"
+  s.version = "0.12.6"
   s.license = "Apache-2.0"
   s.author = "Zakir Durumeric"
   s.email = "zakird@gmail.com"


### PR DESCRIPTION
An official wkhtmltopdf package for Ubuntu 20.04 isn't published yet, but I used [this comment](https://github.com/wkhtmltopdf/packaging/issues/63#issuecomment-626856740) to compile it.