### PR TITLE
Add missing 0.12.6 binary for Ubuntu 20.04

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+# 0.12.6.1
+
+Add missing binary for Ubuntu 20.04
+
 # 0.12.6
 Update `wkhtmltopdf` binaries with version 0.12.6
 Remove binary for Debian 8/Ubuntu 14.04/MacOS Carbon, that is not supported anymore by `wkhtmltopdf`

--- a/wkhtmltopdf-binary.gemspec
+++ b/wkhtmltopdf-binary.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "wkhtmltopdf-binary"
-  s.version = "0.12.6"
+  s.version = "0.12.6.1"
   s.license = "Apache-2.0"
   s.author = "Zakir Durumeric"
   s.email = "zakird@gmail.com"


### PR DESCRIPTION
Closes #86 
Closes #82 
Closes https://github.com/zakird/wkhtmltopdf_binary_gem/pull/77

@unixmonkey 🤝 