### PR TITLE
Organization of the OS mapping

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+# 0.12.6.2
+
+OS mapping for more distros, based in official support OS for wkhtmltopdf
+
 # 0.12.6.1
 
 Add missing binary for Ubuntu 20.04

--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -14,18 +14,23 @@ suffix = case RbConfig::CONFIG['host_os']
          when /linux/
            os = `. /etc/os-release 2> /dev/null && echo ${ID}_${VERSION_ID}`.strip
 
-           if os.start_with?('elementary') || os.start_with?('linuxmint') || os.start_with?('pop')
-             os = 'ubuntu_18.04'
-           end
+           os_based_on_ubuntu_16_04 = os.start_with?('ubuntu_16.')
+           os = 'ubuntu_16.04' if os_based_on_ubuntu_16_04
 
-           # CentOS 6 doesn't have `/etc/os-release`.
-           if (os.empty? && File.read('/etc/centos-release').start_with?('CentOS release 6')) ||
-               os.start_with?('amzn_')
-             os = 'centos_6'
-           end
+           os_based_on_ubuntu_18_04 = os.start_with?('ubuntu_18.') || os.start_with?('elementary') || os.start_with?('linuxmint') || os.start_with?('pop')
+           os = 'ubuntu_18.04' if os_based_on_ubuntu_18_04
 
-           # Deepin fallback
-           os = 'debian_9' if /deepin/.match?(os)
+           os_based_on_ubuntu_20_04 = os.start_with?('ubuntu_20.')
+           os = 'ubuntu_20.04' if os_based_on_ubuntu_20_04
+
+           os_based_on_centos_6 = (os.empty? && File.read('/etc/centos-release').start_with?('CentOS release 6')) || (os.start_with?('amzn_') && !os.start_with?('amzn_2'))
+           os = 'centos_6' if os_based_on_centos_6
+
+           os_based_on_centos_7 = os.start_with?('amzn_2')
+           os = 'centos_7' if os_based_on_centos_7
+
+           os_based_on_debian_9 = /deepin/.match?(os)
+           os = 'debian_9' if os_based_on_debian_9
 
            architecture = RbConfig::CONFIG['host_cpu'] == 'x86_64' ? 'amd64' : 'i386'
 

--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -14,10 +14,10 @@ suffix = case RbConfig::CONFIG['host_os']
          when /linux/
            os = `. /etc/os-release 2> /dev/null && echo ${ID}_${VERSION_ID}`.strip
 
-           os_based_on_ubuntu_16_04 = os.start_with?('ubuntu_16.')
+           os_based_on_ubuntu_16_04 = os.start_with?('ubuntu_16.') || os.start_with?('ubuntu_17.')
            os = 'ubuntu_16.04' if os_based_on_ubuntu_16_04
 
-           os_based_on_ubuntu_18_04 = os.start_with?('ubuntu_18.') || os.start_with?('elementary') || os.start_with?('linuxmint') || os.start_with?('pop')
+           os_based_on_ubuntu_18_04 = os.start_with?('ubuntu_18.') || os.start_with?('ubuntu_19.') || os.start_with?('elementary') || os.start_with?('linuxmint') || os.start_with?('pop')
            os = 'ubuntu_18.04' if os_based_on_ubuntu_18_04
 
            os_based_on_ubuntu_20_04 = os.start_with?('ubuntu_20.')

--- a/wkhtmltopdf-binary.gemspec
+++ b/wkhtmltopdf-binary.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "wkhtmltopdf-binary"
-  s.version = "0.12.6.1"
+  s.version = "0.12.6.2"
   s.license = "Apache-2.0"
   s.author = "Zakir Durumeric"
   s.email = "zakird@gmail.com"


### PR DESCRIPTION
Closes https://github.com/zakird/wkhtmltopdf_binary_gem/pull/84
Closes https://github.com/zakird/wkhtmltopdf_binary_gem/issues/62
Closes https://github.com/zakird/wkhtmltopdf_binary_gem/issues/83

@unixmonkey Many distros are based on official supported OS's by wkhtmltopdf, to I made a little change to provide this mapping, without breaking any existing mapping, and 
 also allow easily to add additional mapping in future 👍 

The current additional mappings:

Ubuntu 16.04, 16.10, 17.04, 17.10 -> 16.04
Elementary, Pop, Linux Mint, Ubuntu 18.04, 18.10, 19.04, 19.10 -> 18.04
Ubuntu 20.04, 20.10 -> 20.04
Amazon Linux 1 -> CentOS 6
Amazon Linux 2 -> CentOS 7
Deepin -> Debian 9