### PR TITLE
support Debian 10 and later on binary

### DIFF
--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -32,6 +32,9 @@ suffix = case RbConfig::CONFIG['host_os']
            os_based_on_debian_9 = (/deepin/ =~ os)
            os = 'debian_9' if os_based_on_debian_9
 
+           os_based_on_debian = os.start_with?('debian')
+           os = 'debian_10' if os_based_on_debian
+
            os_based_on_archlinux = os.start_with?('arch_') || os.start_with?('manjaro_')
            os = 'archlinux' if os_based_on_archlinux
 
@@ -43,7 +46,7 @@ suffix = case RbConfig::CONFIG['host_os']
          else
            'unknown'
          end
-         
+
 suffix = ENV['WKHTMLTOPDF_HOST_SUFFIX'] unless ENV['WKHTMLTOPDF_HOST_SUFFIX'].to_s.empty?
 
 binary = "#{__FILE__}_#{suffix}"


### PR DESCRIPTION
The PR #60 adds support for Debian but it was only for Docker.
This adds a condition to make the `bin/wkhtmltopdf` file use the debian_10
binaries.

fixes #96