### PR TITLE
Prevent using the binary for Debian 10 when running on Debian 9

### DIFF
--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -29,10 +29,10 @@ suffix = case RbConfig::CONFIG['host_os']
            os_based_on_centos_7 = os.start_with?('amzn_2')
            os = 'centos_7' if os_based_on_centos_7
 
-           os_based_on_debian_9 = (/deepin/ =~ os)
+           os_based_on_debian_9 = (/(debian_9|deepin)/ =~ os)
            os = 'debian_9' if os_based_on_debian_9
 
-           os_based_on_debian = os.start_with?('debian')
+           os_based_on_debian = !os_based_on_debian_9 && os.start_with?('debian')
            os = 'debian_10' if os_based_on_debian
 
            os_based_on_archlinux = os.start_with?('arch_') || os.start_with?('manjaro_')


### PR DESCRIPTION
This pull request fixes issue#98.
https://github.com/zakird/wkhtmltopdf_binary_gem/issues/98

I tested on Debian 9. It failed with the original gem, and successfully worked with this pull request's patch.
```sh
$ docker run -it debian:9
Unable to find image 'debian:9' locally
9: Pulling from library/debian
4f250268ed6a: Pull complete 
Digest: sha256:bc125c699d736ac84c92b76ab7028741bbac69f207b7a8a4065bca6f79d5698e
Status: Downloaded newer image for debian:9

root@f3a23c1efa4b: cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 9 (stretch)"
NAME="Debian GNU/Linux"
VERSION_ID="9"
VERSION="9 (stretch)"
VERSION_CODENAME=stretch
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"

root@0751d68ff342: cd /root
root@0751d68ff342: apt-get update
root@0751d68ff342: apt-get install git ruby libjpeg62 libpng16-16 libxrender-dev libfontconfig
root@0751d68ff342: gem install bundler
root@0751d68ff342: echo -e "source 'https://rubygems.org'\ngem 'wkhtmltopdf-binary'" > Gemfile
root@0751d68ff342: bundle install

# with the original gem
root@f3a23c1efa4b: echo "<html><body>It works</body></html>" | bundle exec wkhtmltopdf --quiet --page-size A4 --margin-top 0.75in --margin-right 0.75in --margin-bottom 0.75in --margin-left 0.75in --encoding UTF-8 --enable-local-file-access - - > out.pdf
/var/lib/gems/2.3.0/gems/wkhtmltopdf-binary-0.12.6.4/bin/wkhtmltopdf_debian_10_amd64: /lib/x86_64-linux-gnu/libm.so.6: version 'GLIBC_2.27' not found (required by /var/lib/gems/2.3.0/gems/wkhtmltopdf-binary-0.12.6.4/bin/wkhtmltopdf_debian_10_amd64)
/var/lib/gems/2.3.0/gems/wkhtmltopdf-binary-0.12.6.4/bin/wkhtmltopdf_debian_10_amd64: /lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.28' not found (required by /var/lib/gems/2.3.0/gems/wkhtmltopdf-binary-0.12.6.4/bin/wkhtmltopdf_debian_10_amd64)

# with this pull request's patch
root@0751d68ff342: echo -e "source 'https://rubygems.org'\ngem 'wkhtmltopdf-binary', github: 'johnny-miyake/wkhtmltopdf_binary_gem', branch: 'fix_for_debian9'" > Gemfile
root@0751d68ff342: bundle install
root@f3a23c1efa4b: echo "<html><body>It works</body></html>" | bundle exec wkhtmltopdf --quiet --page-size A4 --margin-top 0.75in --margin-right 0.75in --margin-bottom 0.75in --margin-left 0.75in --encoding UTF-8 --enable-local-file-access - - > out.pdf
```
![screenshot_debian9.png](https://user-images.githubusercontent.com/1129684/95407484-1a6c2880-0958-11eb-9681-901643a23f43.png)


I also tested on Debian 10 just in case, and it worked as well.
```sh
$ docker run -it debian:10                                                                                                                                                                [/Users/i.takuma.miyake/development/wkhtmltopdf_binary_gem]
Unable to find image 'debian:10' locally
10: Pulling from library/debian
Digest: sha256:439a6bae1ef351ba9308fc9a5e69ff7754c14516f6be8ca26975fb564cb7fb76
Status: Downloaded newer image for debian:10

root@b100558ceb6f: cat /etc/os-release 
PRETTY_NAME="Debian GNU/Linux 10 (buster)"
NAME="Debian GNU/Linux"
VERSION_ID="10"
VERSION="10 (buster)"
VERSION_CODENAME=buster
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"

root@0751d68ff342: cd /root
root@0751d68ff342: apt-get update
root@0751d68ff342: apt-get install git ruby libjpeg62 libpng16-16 libxrender-dev libfontconfig
root@0751d68ff342: gem install bundler
root@0751d68ff342: echo -e "source 'https://rubygems.org'\ngem 'wkhtmltopdf-binary', github: 'johnny-miyake/wkhtmltopdf_binary_gem', branch: 'fix_for_debian9'" > Gemfile
root@0751d68ff342: bundle install
root@0751d68ff342: echo "<html><body>It works</body></html>" | bundle exec wkhtmltopdf --quiet --page-size A4 --margin-top 0.75in --margin-right 0.75in --margin-bottom 0.75in --margin-left 0.75in --encoding UTF-8 --enable-local-file-access - - > out.pdf
```
![screenshot_debian10.png](https://user-images.githubusercontent.com/1129684/95407536-412a5f00-0958-11eb-9d5d-7929e1c0957c.png)

