### PR TITLE
Version 0.12.6.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+# 0.12.6.5
+
+Fix ability to use on Debian 9 systems
+
 # 0.12.6.4
 
 Fix version detection for Debian

--- a/wkhtmltopdf-binary.gemspec
+++ b/wkhtmltopdf-binary.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "wkhtmltopdf-binary"
-  s.version = "0.12.6.4"
+  s.version = "0.12.6.5"
   s.license = "Apache-2.0"
   s.author = "Zakir Durumeric"
   s.email = "zakird@gmail.com"


### PR DESCRIPTION
Includes the Debian 9 fix from https://github.com/zakird/wkhtmltopdf_binary_gem/pull/99