### PR TITLE
Add back support for Amazon Linux 1

### DIFF
--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -23,10 +23,13 @@ suffix = case RbConfig::CONFIG['host_os']
            os_based_on_ubuntu_20_04 = os.start_with?('ubuntu_20.')
            os = 'ubuntu_20.04' if os_based_on_ubuntu_20_04
 
-           os_based_on_centos_6 = (os.empty? && File.read('/etc/centos-release').start_with?('CentOS release 6')) || (os.start_with?('amzn_') && os !~ /\Aamzn_2\b/)
+           amazon_2 = os =~ /\Aamzn_2\b/
+           amazon_1 = os.start_with?('amzn_') && !amazon_2
+
+           os_based_on_centos_6 = (os.empty? && File.read('/etc/centos-release').start_with?('CentOS release 6')) || amazon_1
            os = 'centos_6' if os_based_on_centos_6
 
-           os_based_on_centos_7 = os =~ /\Aamzn_2\b/
+           os_based_on_centos_7 = amazon_2
            os = 'centos_7' if os_based_on_centos_7
 
            os_based_on_debian_9 = (/(debian_9|deepin)/ =~ os)

--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -26,7 +26,7 @@ suffix = case RbConfig::CONFIG['host_os']
            os_based_on_centos_6 = (os.empty? && File.read('/etc/centos-release').start_with?('CentOS release 6')) || (os.start_with?('amzn_') && os !~ /\Aamzn_2\b/)
            os = 'centos_6' if os_based_on_centos_6
 
-           os_based_on_centos_7 = os =~ /Aamzn_2\b/
+           os_based_on_centos_7 = os =~ /\Aamzn_2\b/
            os = 'centos_7' if os_based_on_centos_7
 
            os_based_on_debian_9 = (/(debian_9|deepin)/ =~ os)

--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -23,10 +23,10 @@ suffix = case RbConfig::CONFIG['host_os']
            os_based_on_ubuntu_20_04 = os.start_with?('ubuntu_20.')
            os = 'ubuntu_20.04' if os_based_on_ubuntu_20_04
 
-           os_based_on_centos_6 = (os.empty? && File.read('/etc/centos-release').start_with?('CentOS release 6')) || (os.start_with?('amzn_') && !os.start_with?('amzn_2'))
+           os_based_on_centos_6 = (os.empty? && File.read('/etc/centos-release').start_with?('CentOS release 6')) || (os.start_with?('amzn_') && os !~ /\Aamzn_2\b/)
            os = 'centos_6' if os_based_on_centos_6
 
-           os_based_on_centos_7 = os.start_with?('amzn_2')
+           os_based_on_centos_7 = os =~ /Aamzn_2\b/
            os = 'centos_7' if os_based_on_centos_7
 
            os_based_on_debian_9 = (/(debian_9|deepin)/ =~ os)


### PR DESCRIPTION
The `VERSION_ID` for Amazon Linux 1 [can start (always starts?) with a year beginning with "2"](https://stackoverflow.com/a/56576081). This change looks for a word boundary after the "2" to determine whether it's Amazon Linux 1 or 2.