### PR TITLE
Add support to zorin OS

### DIFF
--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -17,7 +17,7 @@ suffix = case RbConfig::CONFIG['host_os']
            os_based_on_ubuntu_16_04 = os.start_with?('ubuntu_16.') || os.start_with?('ubuntu_17.')
            os = 'ubuntu_16.04' if os_based_on_ubuntu_16_04
 
-           os_based_on_ubuntu_18_04 = os.start_with?('ubuntu_18.') || os.start_with?('ubuntu_19.') || os.start_with?('elementary') || os.start_with?('linuxmint') || os.start_with?('pop')
+           os_based_on_ubuntu_18_04 = os.start_with?('ubuntu_18.') || os.start_with?('ubuntu_19.') || os.start_with?('elementary') || os.start_with?('linuxmint') || os.start_with?('pop') || os.start_with?('zorin')
            os = 'ubuntu_18.04' if os_based_on_ubuntu_18_04
 
            os_based_on_ubuntu_20_04 = os.start_with?('ubuntu_20.')


### PR DESCRIPTION
Invalid platform, must be running on Ubuntu 16.04/18.04/20.04 CentOS 6/7/8, Debian 9/10, archlinux amd64, or intel-based Cocoa macOS (missing binary: /home/username/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/wkhtmltopdf-binary-0.12.6.5/bin/wkhtmltopdf_zorin_15_amd64). (RuntimeError)