### PR TITLE
Use the 20.04 binary for 21.04

### DIFF
--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -20,7 +20,7 @@ suffix = case RbConfig::CONFIG['host_os']
            os_based_on_ubuntu_18_04 = os.start_with?('ubuntu_18.') || os.start_with?('ubuntu_19.') || os.start_with?('elementary') || os.start_with?('linuxmint') || os.start_with?('pop') || os.start_with?('zorin')
            os = 'ubuntu_18.04' if os_based_on_ubuntu_18_04
 
-           os_based_on_ubuntu_20_04 = os.start_with?('ubuntu_20.')
+           os_based_on_ubuntu_20_04 = os.start_with?('ubuntu_20.') || os.start_with?('ubuntu_21.')
            os = 'ubuntu_20.04' if os_based_on_ubuntu_20_04
 
            os_based_on_centos_6 = (os.empty? && File.read('/etc/centos-release').start_with?('CentOS release 6')) || (os.start_with?('amzn_') && !os.start_with?('amzn_2'))


### PR DESCRIPTION
Ubuntu 21.04 was released today, and currently this gem errors because it's not supported. I've installed wkhtmltopdf manually on my system using the binary for Focal Fossa (20.04) and it's working fine based on my testing.