### PR TITLE
GitHub actions automation 🤖 ✅ 

### DIFF
--- a/.docker/Dockerfile-archlinux
+++ b/.docker/Dockerfile-archlinux
@@ -1,8 +1,7 @@
-FROM archlinux:latest
+FROM archlinux
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN pacman -Sy --noconfirm \
-  ruby fontconfig freetype2 libjpeg libpng libxext libxrender
+RUN pacman -Sy --noconfirm ruby fontconfig freetype2 libjpeg libpng libxext libxrender
 
 CMD /root/wkhtmltopdf_binary_gem/bin/wkhtmltopdf --version

--- a/.docker/Dockerfile-centos_6
+++ b/.docker/Dockerfile-centos_6
@@ -1,5 +1,9 @@
 FROM centos:6
 
-RUN yum install -y ruby libjpeg-turbo libpng libXrender fontconfig libXext
+RUN rm -f /etc/yum.repos.d/CentOS-Base.repo && \
+    sed -i "s/enabled=0/enabled=1/g" /etc/yum.repos.d/CentOS-Vault.repo && \
+    yum clean all && \
+    yum update -y && \
+    yum install -y ruby libjpeg-turbo libpng libXrender fontconfig libXext
 
 CMD /root/wkhtmltopdf_binary_gem/bin/wkhtmltopdf --version

--- a/.docker/Dockerfile-centos_6
+++ b/.docker/Dockerfile-centos_6
@@ -1,5 +1,7 @@
 FROM centos:6
 
-RUN yum install -y ruby libjpeg-turbo libpng libXrender fontconfig libXext
+RUN yum clean all && \
+    yum update -y && \
+    yum install -y ruby libjpeg-turbo libpng libXrender fontconfig libXext
 
 CMD /root/wkhtmltopdf_binary_gem/bin/wkhtmltopdf --version

--- a/.docker/Dockerfile-centos_6
+++ b/.docker/Dockerfile-centos_6
@@ -1,7 +1,5 @@
 FROM centos:6
 
-RUN yum clean all && \
-    yum update -y && \
-    yum install -y ruby libjpeg-turbo libpng libXrender fontconfig libXext
+RUN yum install -y ruby libjpeg-turbo libpng libXrender fontconfig libXext
 
 CMD /root/wkhtmltopdf_binary_gem/bin/wkhtmltopdf --version

--- a/.docker/Dockerfile-deepin
+++ b/.docker/Dockerfile-deepin
@@ -1,8 +1,0 @@
-FROM deepin/deepin-core:latest
-
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN apt-get update
-RUN apt-get install -y ruby libjpeg8 libxrender1 libfontconfig1
-
-CMD /root/wkhtmltopdf_binary_gem/bin/wkhtmltopdf --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: [3.0]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Run tests with Ruby ${{ matrix.ruby-version }}
+        run: bundle exec rake
+
+      #- name: Build Dockerfile
+      #  run: docker build -t sample .
+
+      #- name: Run tests inside Docker container
+      #  run: docker run -v $(pwd):/some-folder/ -i sample

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, macos-latest]
     strategy:
       matrix:
         ruby-version: [3.0]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby-version: [3.0]
+        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, 3.0]
     steps:
       - uses: actions/checkout@v2
 
@@ -22,9 +22,3 @@ jobs:
 
       - name: Run tests with Ruby ${{ matrix.ruby-version }}
         run: bundle exec rake
-
-      #- name: Build Dockerfile
-      #  run: docker build -t sample .
-
-      #- name: Run tests inside Docker container
-      #  run: docker run -v $(pwd):/some-folder/ -i sample

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install Ruby ${{ matrix.ruby-version }}
+      - name: Install Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
@@ -20,5 +20,5 @@ jobs:
       - name: Install dependencies
         run: bundle install
 
-      - name: Run tests with Ruby ${{ matrix.ruby-version }}
+      - name: Run tests with Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}
         run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,10 @@ on: [push, pull_request]
 
 jobs:
   tests:
-    runs-on: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest]
         ruby-version: [3.0]
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 pkg/*
+Gemfile.lock
 bin/wkhtmltopdf_centos_6_amd64
 bin/wkhtmltopdf_centos_7_amd64
 bin/wkhtmltopdf_centos_8_amd64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.12.6.x
+
+- Setup of Github action automation for Linux/MacOS builds
+
 # 0.12.6.5
 
 Fix ability to use on Debian 9 systems

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+gemspec

--- a/README.md
+++ b/README.md
@@ -51,15 +51,20 @@ macOS
 Binaries should be compressed with `gzip --best` after extracting. The matching binary will be extracted on first
 execution of `bin/wkhtmltopdf`.
 
-## Testing with Docker
+## Testing
 
-Make sure you have Docker and Docker Compose installed (see https://docs.docker.com/compose/install/ for more
-information).
+To execute gem tests locally, install in your OS:
 
-There are Dockerfiles for the supported Linux based distributions under `.docker`. You can build them all with
-`docker-compose build` and run each individually with e.g. `docker-compose run ubuntu_18.04`.
+- Docker
+- Docker compose
+- Ruby
+- Bundler
 
-There also is a rudimentary minitest test that simply invokes `docker-compose run` for each distribution and
-expects to see the output of `wkhtmltopdf --version`. Just run `rake` to run it.
+Then, execute the commands below:
 
-You can clean up after testing with `docker-compose down --rmi all`.
+```bash
+git clone https://github.com/zakird/wkhtmltopdf_binary_gem
+cd wkhtmltopdf_binary_gem/
+bundle install
+bundle exec rake
+```

--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -14,29 +14,33 @@ suffix = case RbConfig::CONFIG['host_os']
          when /linux/
            os = `. /etc/os-release 2> /dev/null && echo ${ID}_${VERSION_ID}`.strip
 
-           os_based_on_ubuntu_16_04 = os.start_with?('ubuntu_16.') || os.start_with?('ubuntu_17.')
-           os = 'ubuntu_16.04' if os_based_on_ubuntu_16_04
+           os = 'ubuntu_16.04' if os.start_with?('ubuntu_16.') ||
+                                  os.start_with?('ubuntu_17.')
 
-           os_based_on_ubuntu_18_04 = os.start_with?('ubuntu_18.') || os.start_with?('ubuntu_19.') || os.start_with?('elementary') || os.start_with?('linuxmint') || os.start_with?('pop') || os.start_with?('zorin')
-           os = 'ubuntu_18.04' if os_based_on_ubuntu_18_04
+           os = 'ubuntu_18.04' if os.start_with?('ubuntu_18.') ||
+                                  os.start_with?('ubuntu_19.') ||
+                                  os.start_with?('elementary') ||
+                                  os.start_with?('linuxmint') ||
+                                  os.start_with?('pop') ||
+                                  os.start_with?('zorin')
 
-           os_based_on_ubuntu_20_04 = os.start_with?('ubuntu_20.') || os.start_with?('ubuntu_21.')
-           os = 'ubuntu_20.04' if os_based_on_ubuntu_20_04
+           os = 'ubuntu_20.04' if os.start_with?('ubuntu_20.') ||
+                                  os.start_with?('ubuntu_21.')
 
-           os_based_on_centos_6 = (os.empty? && File.read('/etc/centos-release').start_with?('CentOS release 6')) || (os.start_with?('amzn_') && !os.start_with?('amzn_2'))
-           os = 'centos_6' if os_based_on_centos_6
+           os = 'centos_6' if (os.start_with?('amzn_') && !os.start_with?('amzn_2')) ||
+                              (os.empty? && File.read('/etc/centos-release').start_with?('CentOS release 6'))
 
-           os_based_on_centos_7 = os.start_with?('amzn_2') || os.start_with?('rhel_7.')
-           os = 'centos_7' if os_based_on_centos_7
+           os = 'centos_7' if os.start_with?('amzn_2') ||
+                              os.start_with?('rhel_7.')
 
-           os_based_on_debian_9 = (/(debian_9|deepin)/ =~ os)
+           os_based_on_debian_9 = os.start_with?('debian_9') ||
+                                  os.start_with?('deepin')
            os = 'debian_9' if os_based_on_debian_9
 
-           os_based_on_debian = !os_based_on_debian_9 && os.start_with?('debian')
-           os = 'debian_10' if os_based_on_debian
+           os = 'debian_10' if !os_based_on_debian_9 && os.start_with?('debian')
 
-           os_based_on_archlinux = os.start_with?('arch_') || os.start_with?('manjaro_')
-           os = 'archlinux' if os_based_on_archlinux
+           os = 'archlinux' if os.start_with?('arch_') ||
+                               os.start_with?('manjaro_')
 
            architecture = RbConfig::CONFIG['host_cpu'] == 'x86_64' ? 'amd64' : 'i386'
 
@@ -58,8 +62,8 @@ if File.exist?("#{binary}.gz") && !File.exist?(binary)
 end
 
 unless File.exist? binary
-  raise 'Invalid platform, must be running on Ubuntu 16.04/18.04/20.04 ' \
-        'CentOS 6/7/8, Debian 9/10, archlinux amd64, or intel-based Cocoa macOS ' \
+  raise 'Invalid platform, must be running on Ubuntu 16.04/18.04/20.04, ' \
+        'CentOS 6/7/8, Debian 9/10, Archlinux amd64, or Intel-based Cocoa macOS ' \
         "(missing binary: #{binary})."
 end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,54 +2,54 @@ version: '3'
 
 services:
 
-  ubuntu_16.04:
-    build:
-      context: .
-      dockerfile: .docker/Dockerfile-ubuntu_16.04
-    volumes:
-      - .:/root/wkhtmltopdf_binary_gem
+  # ubuntu_16.04:
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Dockerfile-ubuntu_16.04
+  #   volumes:
+  #     - .:/root/wkhtmltopdf_binary_gem
 
-  ubuntu_18.04:
-    build:
-      context: .
-      dockerfile: .docker/Dockerfile-ubuntu_18.04
-    volumes:
-      - .:/root/wkhtmltopdf_binary_gem
+  # ubuntu_18.04:
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Dockerfile-ubuntu_18.04
+  #   volumes:
+  #     - .:/root/wkhtmltopdf_binary_gem
 
-  ubuntu_20.04:
-    build:
-      context: .
-      dockerfile: .docker/Dockerfile-ubuntu_20.04
-    volumes:
-      - .:/root/wkhtmltopdf_binary_gem
+  # ubuntu_20.04:
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Dockerfile-ubuntu_20.04
+  #   volumes:
+  #     - .:/root/wkhtmltopdf_binary_gem
 
-  debian_9:
-    build:
-      context: .
-      dockerfile: .docker/Dockerfile-debian_9
-    volumes:
-      - .:/root/wkhtmltopdf_binary_gem
+  # debian_9:
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Dockerfile-debian_9
+  #   volumes:
+  #     - .:/root/wkhtmltopdf_binary_gem
 
-  debian_10:
-    build:
-      context: .
-      dockerfile: .docker/Dockerfile-debian_10
-    volumes:
-      - .:/root/wkhtmltopdf_binary_gem
+  # debian_10:
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Dockerfile-debian_10
+  #   volumes:
+  #     - .:/root/wkhtmltopdf_binary_gem
 
-  centos_6:
-    build:
-      context: .
-      dockerfile: .docker/Dockerfile-centos_6
-    volumes:
-      - .:/root/wkhtmltopdf_binary_gem
+  # centos_6:
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Dockerfile-centos_6
+  #   volumes:
+  #     - .:/root/wkhtmltopdf_binary_gem
 
-  centos_7:
-    build:
-      context: .
-      dockerfile: .docker/Dockerfile-centos_7
-    volumes:
-      - .:/root/wkhtmltopdf_binary_gem
+  # centos_7:
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Dockerfile-centos_7
+  #   volumes:
+  #     - .:/root/wkhtmltopdf_binary_gem
 
   centos_8:
     build:
@@ -58,16 +58,16 @@ services:
     volumes:
       - .:/root/wkhtmltopdf_binary_gem
 
-  deepin:
-    build:
-      context: .
-      dockerfile: .docker/Dockerfile-deepin
-    volumes:
-      - .:/root/wkhtmltopdf_binary_gem
+  # deepin:
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Dockerfile-deepin
+  #   volumes:
+  #     - .:/root/wkhtmltopdf_binary_gem
 
-  archlinux:
-    build:
-      context: .
-      dockerfile: .docker/Dockerfile-archlinux
-    volumes:
-      - .:/root/wkhtmltopdf_binary_gem
+  # archlinux:
+  #   build:
+  #     context: .
+  #     dockerfile: .docker/Dockerfile-archlinux
+  #   volumes:
+  #     - .:/root/wkhtmltopdf_binary_gem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,16 +58,9 @@ services:
     volumes:
       - .:/root/wkhtmltopdf_binary_gem
 
-  # deepin:
-  #   build:
-  #     context: .
-  #     dockerfile: .docker/Dockerfile-deepin
-  #   volumes:
-  #     - .:/root/wkhtmltopdf_binary_gem
-
-  # archlinux:
-  #   build:
-  #     context: .
-  #     dockerfile: .docker/Dockerfile-archlinux
-  #   volumes:
-  #     - .:/root/wkhtmltopdf_binary_gem
+  archlinux:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile-archlinux
+    volumes:
+      - .:/root/wkhtmltopdf_binary_gem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,12 +37,12 @@ services:
   #   volumes:
   #     - .:/root/wkhtmltopdf_binary_gem
 
-  # centos_6:
-  #   build:
-  #     context: .
-  #     dockerfile: .docker/Dockerfile-centos_6
-  #   volumes:
-  #     - .:/root/wkhtmltopdf_binary_gem
+  centos_6:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile-centos_6
+    volumes:
+      - .:/root/wkhtmltopdf_binary_gem
 
   centos_7:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,12 +44,12 @@ services:
   #   volumes:
   #     - .:/root/wkhtmltopdf_binary_gem
 
-  # centos_7:
-  #   build:
-  #     context: .
-  #     dockerfile: .docker/Dockerfile-centos_7
-  #   volumes:
-  #     - .:/root/wkhtmltopdf_binary_gem
+  centos_7:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile-centos_7
+    volumes:
+      - .:/root/wkhtmltopdf_binary_gem
 
   centos_8:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,12 +23,12 @@ services:
   #   volumes:
   #     - .:/root/wkhtmltopdf_binary_gem
 
-  # debian_9:
-  #   build:
-  #     context: .
-  #     dockerfile: .docker/Dockerfile-debian_9
-  #   volumes:
-  #     - .:/root/wkhtmltopdf_binary_gem
+  debian_9:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile-debian_9
+    volumes:
+      - .:/root/wkhtmltopdf_binary_gem
 
   # debian_10:
   #   build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,26 +2,26 @@ version: '3'
 
 services:
 
-  # ubuntu_16.04:
-  #   build:
-  #     context: .
-  #     dockerfile: .docker/Dockerfile-ubuntu_16.04
-  #   volumes:
-  #     - .:/root/wkhtmltopdf_binary_gem
+  ubuntu_16.04:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile-ubuntu_16.04
+    volumes:
+      - .:/root/wkhtmltopdf_binary_gem
 
-  # ubuntu_18.04:
-  #   build:
-  #     context: .
-  #     dockerfile: .docker/Dockerfile-ubuntu_18.04
-  #   volumes:
-  #     - .:/root/wkhtmltopdf_binary_gem
+  ubuntu_18.04:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile-ubuntu_18.04
+    volumes:
+      - .:/root/wkhtmltopdf_binary_gem
 
-  # ubuntu_20.04:
-  #   build:
-  #     context: .
-  #     dockerfile: .docker/Dockerfile-ubuntu_20.04
-  #   volumes:
-  #     - .:/root/wkhtmltopdf_binary_gem
+  ubuntu_20.04:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile-ubuntu_20.04
+    volumes:
+      - .:/root/wkhtmltopdf_binary_gem
 
   debian_9:
     build:
@@ -30,12 +30,12 @@ services:
     volumes:
       - .:/root/wkhtmltopdf_binary_gem
 
-  # debian_10:
-  #   build:
-  #     context: .
-  #     dockerfile: .docker/Dockerfile-debian_10
-  #   volumes:
-  #     - .:/root/wkhtmltopdf_binary_gem
+  debian_10:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile-debian_10
+    volumes:
+      - .:/root/wkhtmltopdf_binary_gem
 
   centos_6:
     build:

--- a/test/test_with_docker.rb
+++ b/test/test_with_docker.rb
@@ -10,13 +10,13 @@ class WithDockerTest < Minitest::Test
   #  test with: 'centos_6'
   #end
 
-  def test_centos_7
-    test with: 'centos_7'
-  end
+  #def test_centos_7
+  #  test with: 'centos_7'
+  #end
 
-  def test_centos_8
-    test with: 'centos_8'
-  end
+  #def test_centos_8
+  #  test with: 'centos_8'
+  #end
 
   def test_debian_9
     test with: 'debian_9'

--- a/test/test_with_docker.rb
+++ b/test/test_with_docker.rb
@@ -38,9 +38,9 @@ class WithDockerTest < Minitest::Test
     test with: 'ubuntu_20.04'
   end
 
-  def test_with_archlinux
-    test with: 'archlinux'
-  end
+  #def test_with_archlinux
+  #  test with: 'archlinux'
+  #end
 
   def test_with_macos
     assert_equal `bin/wkhtmltopdf --version`.strip, 'wkhtmltopdf 0.12.6 (with patched qt)'

--- a/test/test_with_docker.rb
+++ b/test/test_with_docker.rb
@@ -7,7 +7,7 @@ end
 class WithDockerTest < Minitest::Test
   # Run code before a group of test (see: https://github.com/seattlerb/minitest#how-to-run-code-before-a-group-of-tests)
   SETUP = begin
-    `docker-compose build` unless macos?
+    `docker-compose build --no-cache` unless macos?
   end
 
   #def test_centos_6
@@ -18,29 +18,29 @@ class WithDockerTest < Minitest::Test
   #  test with: 'centos_7'
   #end
 
-  #def test_centos_8
-  #  test with: 'centos_8'
+  def test_centos_8
+   test with: 'centos_8'
+  end
+
+  #def test_debian_9
+  #  test with: 'debian_9'
   #end
 
-  def test_debian_9
-    test with: 'debian_9'
-  end
+  #def test_debian_10
+  #  test with: 'debian_10'
+  #end
 
-  def test_debian_10
-    test with: 'debian_10'
-  end
+  #def test_with_ubuntu_16
+  #  test with: 'ubuntu_16.04'
+  #end
 
-  def test_with_ubuntu_16
-    test with: 'ubuntu_16.04'
-  end
+  #def test_with_ubuntu_18
+  #  test with: 'ubuntu_18.04'
+  #end
 
-  def test_with_ubuntu_18
-    test with: 'ubuntu_18.04'
-  end
-
-  def test_with_ubuntu_20
-    test with: 'ubuntu_20.04'
-  end
+  #def test_with_ubuntu_20
+  #  test with: 'ubuntu_20.04'
+  #end
 
   #def test_with_deepin
   #  test with: 'deepin'
@@ -50,9 +50,9 @@ class WithDockerTest < Minitest::Test
   #  test with: 'archlinux'
   #end
 
-  def test_with_macos
-    assert_equal `bin/wkhtmltopdf --version`.strip, 'wkhtmltopdf 0.12.6 (with patched qt)' if macos?
-  end
+  #def test_with_macos
+  #  assert_equal `bin/wkhtmltopdf --version`.strip, 'wkhtmltopdf 0.12.6 (with patched qt)' if macos?
+  #end
 
   private
 

--- a/test/test_with_docker.rb
+++ b/test/test_with_docker.rb
@@ -42,6 +42,10 @@ class WithDockerTest < Minitest::Test
     test with: 'ubuntu_20.04'
   end
 
+  def test_with_deepin
+    test with: 'deepin'
+  end
+
   #def test_with_archlinux
   #  test with: 'archlinux'
   #end

--- a/test/test_with_docker.rb
+++ b/test/test_with_docker.rb
@@ -21,9 +21,9 @@ class WithDockerTest < Minitest::Test
    test with: 'centos_8'
   end
 
-  #def test_debian_9
-  #  test with: 'debian_9'
-  #end
+  def test_debian_9
+   test with: 'debian_9'
+  end
 
   #def test_debian_10
   #  test with: 'debian_10'

--- a/test/test_with_docker.rb
+++ b/test/test_with_docker.rb
@@ -41,13 +41,9 @@ class WithDockerTest < Minitest::Test
    test with: 'ubuntu_20.04'
   end
 
-  #def test_with_deepin
-  #  test with: 'deepin'
-  #end
-
-  #def test_with_archlinux
-  #  test with: 'archlinux'
-  #end
+  def test_with_archlinux
+   test with: 'archlinux'
+  end
 
   def test_with_macos
    assert_equal(`bin/wkhtmltopdf --version`.strip, 'wkhtmltopdf 0.12.6 (with patched qt)') if macos?

--- a/test/test_with_docker.rb
+++ b/test/test_with_docker.rb
@@ -25,21 +25,21 @@ class WithDockerTest < Minitest::Test
    test with: 'debian_9'
   end
 
-  #def test_debian_10
-  #  test with: 'debian_10'
-  #end
+  def test_debian_10
+   test with: 'debian_10'
+  end
 
-  #def test_with_ubuntu_16
-  #  test with: 'ubuntu_16.04'
-  #end
+  def test_with_ubuntu_16
+   test with: 'ubuntu_16.04'
+  end
 
-  #def test_with_ubuntu_18
-  #  test with: 'ubuntu_18.04'
-  #end
+  def test_with_ubuntu_18
+   test with: 'ubuntu_18.04'
+  end
 
-  #def test_with_ubuntu_20
-  #  test with: 'ubuntu_20.04'
-  #end
+  def test_with_ubuntu_20
+   test with: 'ubuntu_20.04'
+  end
 
   #def test_with_deepin
   #  test with: 'deepin'
@@ -49,13 +49,13 @@ class WithDockerTest < Minitest::Test
   #  test with: 'archlinux'
   #end
 
-  #def test_with_macos
-  #  assert_equal `bin/wkhtmltopdf --version`.strip, 'wkhtmltopdf 0.12.6 (with patched qt)' if macos?
-  #end
+  def test_with_macos
+   assert_equal(`bin/wkhtmltopdf --version`.strip, 'wkhtmltopdf 0.12.6 (with patched qt)') if macos?
+  end
 
   private
 
   def test(with:)
-    assert_equal `docker-compose run --rm #{with}`.strip, 'wkhtmltopdf 0.12.6 (with patched qt)' unless macos?
+    assert_equal(`docker-compose run --rm #{with}`.strip, 'wkhtmltopdf 0.12.6 (with patched qt)') unless macos?
   end
 end

--- a/test/test_with_docker.rb
+++ b/test/test_with_docker.rb
@@ -14,9 +14,9 @@ class WithDockerTest < Minitest::Test
   #  test with: 'centos_6'
   #end
 
-  #def test_centos_7
-  #  test with: 'centos_7'
-  #end
+  def test_centos_7
+    test with: 'centos_7'
+  end
 
   def test_centos_8
    test with: 'centos_8'

--- a/test/test_with_docker.rb
+++ b/test/test_with_docker.rb
@@ -42,9 +42,9 @@ class WithDockerTest < Minitest::Test
     test with: 'ubuntu_20.04'
   end
 
-  def test_with_deepin
-    test with: 'deepin'
-  end
+  #def test_with_deepin
+  #  test with: 'deepin'
+  #end
 
   #def test_with_archlinux
   #  test with: 'archlinux'

--- a/test/test_with_docker.rb
+++ b/test/test_with_docker.rb
@@ -5,14 +5,13 @@ def macos?
 end
 
 class WithDockerTest < Minitest::Test
-  # Run code before a group of test (see: https://github.com/seattlerb/minitest#how-to-run-code-before-a-group-of-tests)
   SETUP = begin
     `docker-compose build --no-cache` unless macos?
   end
 
-  #def test_centos_6
-  #  test with: 'centos_6'
-  #end
+  def test_centos_6
+   test with: 'centos_6'
+  end
 
   def test_centos_7
     test with: 'centos_7'

--- a/test/test_with_docker.rb
+++ b/test/test_with_docker.rb
@@ -1,9 +1,13 @@
 require 'minitest/autorun'
 
+def macos?
+  ENV['RUNNER_OS'] && ENV['RUNNER_OS'] == 'macOS'
+end
+
 class WithDockerTest < Minitest::Test
   # Run code before a group of test (see: https://github.com/seattlerb/minitest#how-to-run-code-before-a-group-of-tests)
   SETUP = begin
-    `docker-compose build`
+    `docker-compose build` unless macos?
   end
 
   #def test_centos_6
@@ -43,12 +47,12 @@ class WithDockerTest < Minitest::Test
   #end
 
   def test_with_macos
-    assert_equal `bin/wkhtmltopdf --version`.strip, 'wkhtmltopdf 0.12.6 (with patched qt)'
+    assert_equal `bin/wkhtmltopdf --version`.strip, 'wkhtmltopdf 0.12.6 (with patched qt)' if macos?
   end
 
   private
 
   def test(with:)
-    assert_equal `docker-compose run --rm #{with}`.strip, 'wkhtmltopdf 0.12.6 (with patched qt)'
+    assert_equal `docker-compose run --rm #{with}`.strip, 'wkhtmltopdf 0.12.6 (with patched qt)' unless macos?
   end
 end

--- a/test/test_with_docker.rb
+++ b/test/test_with_docker.rb
@@ -6,9 +6,9 @@ class WithDockerTest < Minitest::Test
     `docker-compose build`
   end
 
-  def test_centos_6
-    test with: 'centos_6'
-  end
+  #def test_centos_6
+  #  test with: 'centos_6'
+  #end
 
   def test_centos_7
     test with: 'centos_7'

--- a/wkhtmltopdf-binary.gemspec
+++ b/wkhtmltopdf-binary.gemspec
@@ -13,4 +13,5 @@ Gem::Specification.new do |s|
   s.require_path = '.'
 
   s.add_development_dependency "minitest"
+  s.add_development_dependency "rake"
 end


### PR DESCRIPTION
Closes #114 

Hello, @unixmonkey ! 👋 

In order to provide us more automation in future PRs and changes, I added a complete Github Action workflow, that tests gem in all official base distros that we have binaries (including macos 🎉 ). Any derivated distro supported (deepin, amzn and so on) doesn't need (at least for a while) to be included in test suite.

Once this merged, we will get a stronger test suite in each change made in repo 🍻 

Let me know your impressions about it, it will be awesome 🤝 🤓 

Ps: You can check a example of the automation in this links, that contains the CI for last commit of PR: https://github.com/pedrofurtado/wkhtmltopdf_binary_gem/actions/runs/1061475630

Ps: None gem behavior was changed, and the CI is all green 🏁 ✅ 