### PR TITLE
🤖 Github automation to publish gem in Rubygems (Dispatching workflow in actions tab, by repo admins)

### DIFF
--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -1,0 +1,28 @@
+name: Publish to Rubygems
+
+on: [workflow_dispatch]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Publish to Rubygems
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          gem push *.gem
+        env:
+          GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"


### PR DESCRIPTION
@unixmonkey Hi again! 👋 

I think this automation can help us a lot, in order to publish versions in rubygems without need to clone/build/publish manually in our PC or something else.

Once released is done, and the version is defined in `version.rb`, we just need to dispatch the workflow in Github Actions tab. Only repo admins can make this action, and that is great 🍻 

What do you think about?