### PR TITLE
Add support for Rocky 8

### DIFF
--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -32,7 +32,9 @@ suffix = case RbConfig::CONFIG['host_os']
 
            os = 'centos_7' if (os.start_with?('amzn_2') && !os.start_with?('amzn_20')) ||
                               os.start_with?('rhel_7.')
-
+           
+           os = 'centos_8' if os.start_with?('rocky_8')
+           
            os_based_on_debian_9 = os.start_with?('debian_9') ||
                                   os.start_with?('deepin')
            os = 'debian_9' if os_based_on_debian_9


### PR DESCRIPTION
With the EOL of Centos reached some of us will migrate to Rocky Linux.
So it would be good to support Rocky linux 8.
We can use the same binary as Centos 8 for that