### PR TITLE
Checks if the extracted binary size is 0 and extracts if so

### DIFF
--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -57,7 +57,7 @@ suffix = ENV['WKHTMLTOPDF_HOST_SUFFIX'] unless ENV['WKHTMLTOPDF_HOST_SUFFIX'].to
 
 binary = "#{__FILE__}_#{suffix}"
 
-if File.exist?("#{binary}.gz") && !File.exist?(binary)
+if File.exist?("#{binary}.gz") && (!File.exist?(binary) || (File.exist?(binary) && File.size(binary) == 0))
   File.open binary, 'wb', 0o755 do |file|
     Zlib::GzipReader.open("#{binary}.gz") { |gzip| file << gzip.read }
   end


### PR DESCRIPTION
We ran into an issue recently wherein the binary extraction failed silently and resulted in a file with 0 bytes.  Because the check on bin/wkhtmltopdf:60 does not check for filesize, only that the file doesn't exist, the proper binary was never extracted.  This Pull Request adds an additional check so that it will perform the extract if the file exists but the size is 0