### PR TITLE
Add Ruby "3.0" support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, 3.0]
+        ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1']
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Now the CI doesn't test with Ruby 3.0, but 3.1.

ref: https://bibwild.wordpress.com/2021/12/28/github-action-setup-ruby-needs-to-quote-3-0-or-will-end-up-with-ruby-3-1/