### PR TITLE
Add some URLs to gemspec

### DIFF
--- a/wkhtmltopdf-binary.gemspec
+++ b/wkhtmltopdf-binary.gemspec
@@ -11,6 +11,10 @@ Gem::Specification.new do |s|
   s.files = Dir['bin/*']
   s.executables << "wkhtmltopdf"
   s.require_path = '.'
+  s.homepage = 'https://github.com/zakird/wkhtmltopdf_binary_gem'
+
+  spec.metadata['source_code_uri'] = spec.homepage
+  spec.metadata['changelog_uri'] = "#{spec.homepage}/blob/master/CHANGELOG.md"
 
   s.add_development_dependency "minitest"
   s.add_development_dependency "rake"


### PR DESCRIPTION
It would be nice if there are links from https://rubygems.org/gems/wkhtmltopdf-binary to its source code and changelog. Of course, this information is useful not only for rubygems.org, but also for various update support tools.

It used to be possible to edit the URL at rubygems.org, but this is no longer possible, so I think it is preferable to include it in the gemspec.

![image](https://user-images.githubusercontent.com/111689/175793558-c531c1fe-2677-4e24-8902-29c8d2139617.png)

