### PR TITLE
Add support for Ubuntu 22.04

### DIFF
--- a/.docker/Dockerfile-ubuntu_22.04
+++ b/.docker/Dockerfile-ubuntu_22.04
@@ -1,0 +1,8 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update
+RUN apt-get install -y ruby libjpeg8 libxrender1 libfontconfig1
+
+CMD /root/wkhtmltopdf_binary_gem/bin/wkhtmltopdf --version

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ bin/wkhtmltopdf_macos_cocoa
 bin/wkhtmltopdf_ubuntu_16.04_amd64
 bin/wkhtmltopdf_ubuntu_18.04_amd64
 bin/wkhtmltopdf_ubuntu_20.04_amd64
+bin/wkhtmltopdf_ubuntu_22.04_amd64
 bin/wkhtmltopdf_centos_6_i386
 bin/wkhtmltopdf_centos_7_i386
 bin/wkhtmltopdf_debian_9_i386

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Setup of Github action automation for Linux/MacOS builds
 
+# 0.12.6.6
+
+Add support for Ubuntu 22.04
+
 # 0.12.6.5
 
 Fix ability to use on Debian 9 systems

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ macOS
 Binaries should be compressed with `gzip --best` after extracting. The matching binary will be extracted on first
 execution of `bin/wkhtmltopdf`.
 
+Hints for compressing binaries
+
+Debian/Ubuntu
+    user/local/bin refers to the extracted binaries directory
+    gzip --best -c usr/local/bin/wkhtmltopdf > wkhtmltopdf_ubuntu_22.04.amd64.gz
+
 ## Testing
 
 To execute gem tests locally, install in your OS:

--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -27,6 +27,8 @@ suffix = case RbConfig::CONFIG['host_os']
            os = 'ubuntu_20.04' if os.start_with?('ubuntu_20.') ||
                                   os.start_with?('ubuntu_21.')
 
+           os = 'ubuntu_22.04' if os.start_with?('ubuntu_22.')
+
            os = 'centos_6' if (os.start_with?('amzn_') && os != 'amzn_2') ||
                               (os.empty? && File.read('/etc/centos-release').start_with?('CentOS release 6'))
 
@@ -64,7 +66,7 @@ if File.exist?("#{binary}.gz") && !File.exist?(binary)
 end
 
 unless File.exist? binary
-  raise 'Invalid platform, must be running on Ubuntu 16.04/18.04/20.04, ' \
+  raise 'Invalid platform, must be running on Ubuntu 16.04/18.04/20.04/22.04, ' \
         'CentOS 6/7/8, Debian 9/10, Archlinux amd64, or Intel-based Cocoa macOS ' \
         "(missing binary: #{binary})."
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,13 @@ services:
     volumes:
       - .:/root/wkhtmltopdf_binary_gem
 
+  ubuntu_22.04:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile-ubuntu_22.04
+    volumes:
+      - .:/root/wkhtmltopdf_binary_gem
+
   debian_9:
     build:
       context: .

--- a/test/test_with_docker.rb
+++ b/test/test_with_docker.rb
@@ -41,6 +41,10 @@ class WithDockerTest < Minitest::Test
    test with: 'ubuntu_20.04'
   end
 
+  def test_with_ubuntu_22
+   test with: 'ubuntu_22.04'
+  end
+
   def test_with_archlinux
    test with: 'archlinux'
   end

--- a/wkhtmltopdf-binary.gemspec
+++ b/wkhtmltopdf-binary.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "wkhtmltopdf-binary"
-  s.version = "0.12.6.5"
+  s.version = "0.12.6.6"
   s.license = "Apache-2.0"
   s.author = "Zakir Durumeric"
   s.email = "zakird@gmail.com"


### PR DESCRIPTION
It has been a while since ubuntu 22.04 is out. this commit adds ubuntu 22.04 wkhtmltopdf binaries to the gem