### PR TITLE
A more testable linux version detector

### DIFF
--- a/.docker/Dockerfile-amazon-2
+++ b/.docker/Dockerfile-amazon-2
@@ -1,0 +1,6 @@
+FROM amazonlinux:2
+
+RUN yum update -y && \
+    yum install -y ruby libjpeg-turbo libpng libXrender fontconfig libXext openssl
+
+CMD /root/wkhtmltopdf_binary_gem/bin/wkhtmltopdf --version

--- a/.docker/Dockerfile-amazon-2022
+++ b/.docker/Dockerfile-amazon-2022
@@ -1,0 +1,6 @@
+FROM amazonlinux:2022
+
+RUN yum update -y && \
+    yum install -y ruby libjpeg-turbo libpng libXrender fontconfig libXext openssl
+
+CMD /root/wkhtmltopdf_binary_gem/bin/wkhtmltopdf --version

--- a/Rakefile
+++ b/Rakefile
@@ -12,5 +12,10 @@ Rake::TestTask.new do |t|
   t.libs << 'test'
 end
 
+Rake::TestTask.new do |t|
+  t.name = 'unit'
+  t.pattern = 'test/wkhtmltopdf/**/*.rb'
+end
+
 desc 'Run tests'
-task default: :test
+task default: [:unit, :test]

--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -10,44 +10,18 @@
 require 'rbconfig'
 require 'zlib'
 
+$LOAD_PATH.unshift File.expand_path('../lib/', File.dirname(__FILE__))
+require 'wkhtmltopdf/linux_os_detector'
+
 suffix = case RbConfig::CONFIG['host_os']
          when /linux/
-           os = `. /etc/os-release 2> /dev/null && echo ${ID}_${VERSION_ID}`.strip
+           id, version = if File.exist?('/etc/os-release')
+                          `. /etc/os-release 2> /dev/null && echo ${ID} ${VERSION_ID}`.strip.split
+                         else
+                          ['', '']
+                         end
 
-           os = 'ubuntu_16.04' if os.start_with?('ubuntu_16.') ||
-                                  os.start_with?('ubuntu_17.') ||
-                                  os.start_with?('linuxmint_18.')
-
-           os = 'ubuntu_18.04' if os.start_with?('ubuntu_18.') ||
-                                  os.start_with?('ubuntu_19.') ||
-                                  os.start_with?('elementary') ||
-                                  os.start_with?('linuxmint_19.') ||
-                                  os.start_with?('pop') ||
-                                  os.start_with?('zorin')
-
-           os = 'ubuntu_20.04' if os.start_with?('ubuntu_20.') ||
-                                  os.start_with?('ubuntu_21.') ||
-                                  os.start_with?('linuxmint_20.')
-
-           os = 'ubuntu_22.04' if os.start_with?('ubuntu_22.') ||
-                                  os.start_with?('linuxmint_21.')
-
-           os = 'centos_6' if (os.start_with?('amzn_') && os != 'amzn_2') ||
-                              (os.empty? && File.read('/etc/centos-release').start_with?('CentOS release 6'))
-
-           os = 'centos_7' if (os.start_with?('amzn_2') && !os.start_with?('amzn_20')) ||
-                              os.start_with?('rhel_7.')
-
-           os = 'centos_8' if os.start_with?('rocky_8') || os.start_with?('rhel_8.')
-
-           os_based_on_debian_9 = os.start_with?('debian_9') ||
-                                  os.start_with?('deepin')
-           os = 'debian_9' if os_based_on_debian_9
-
-           os = 'debian_10' if !os_based_on_debian_9 && os.start_with?('debian')
-
-           os = 'archlinux' if os.start_with?('arch_') ||
-                               os.start_with?('manjaro_')
+           os = Wkhtmltopdf::LinuxOsDetector.new(id, version).os
 
            architecture = RbConfig::CONFIG['host_cpu'] == 'x86_64' ? 'amd64' : 'i386'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,3 +77,17 @@ services:
       dockerfile: .docker/Dockerfile-archlinux
     volumes:
       - .:/root/wkhtmltopdf_binary_gem
+
+  amazon_2:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile-amazon-2
+    volumes:
+      - .:/root/wkhtmltopdf_binary_gem
+
+  amazon_2022:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile-amazon-2022
+    volumes:
+      - .:/root/wkhtmltopdf_binary_gem

--- a/lib/wkhtmltopdf/linux_os_detector.rb
+++ b/lib/wkhtmltopdf/linux_os_detector.rb
@@ -1,0 +1,101 @@
+module Wkhtmltopdf
+  class LinuxOsDetector
+
+    def initialize(id, version)
+      raise ArgumentError if id.nil? || version.nil?
+
+      @id = id
+      @version = version
+      @extras = {}
+    end
+
+    def os
+      gather_extra_information
+
+      return special_cases if id.empty?
+      return send(id) if self.respond_to?(id, true)
+      "#{id}_#{version}"
+    end
+
+    private
+
+    def gather_extra_information
+      @extras['centos-release'] = File.read('/etc/centos-release') if File.exist?('/etc/centos-release')
+    end
+
+    def special_cases
+      if @extras.key?('centos-release') && @extras['centos-release'].start_with?('CentOS release 6')
+        'centos_6'
+      end
+    end
+
+    def linuxmint
+      case version
+      when /^18/; 'ubuntu_16.04'
+      when /^19/; 'ubuntu_18.04'
+      when /^20/; 'ubuntu_20.04'
+      when /^21/; 'ubuntu_22.04'
+      end
+    end
+
+    def ubuntu
+      case version
+      when /^(16|17)/; 'ubuntu_16.04'
+      when /^(18|19)/; 'ubuntu_18.04'
+      when /^(20|21)/; 'ubuntu_20.04'
+      when /^(22)/; 'ubuntu_22.04'
+      end
+    end
+
+    def debian
+      case version
+      when '9'; 'debian_9'
+      else; 'debian_10'
+      end
+    end
+
+    def deepin
+      'debian_9'
+    end
+
+    def amzn
+      case version
+      when '2'; 'centos_7'
+      when /^2018/; 'centos_6'
+      when /^2022/; 'centos_7'
+      end
+    end
+
+    def rhel
+      case version
+      when /^8\./; 'centos_8'
+      end
+    end
+
+    def rocky
+      'centos_8'
+    end
+
+    def arch
+      'archlinux'
+    end
+
+    def manjaro
+      'archlinux'
+    end
+
+    def zorin
+      'ubuntu_18.04'
+    end
+
+    def pop
+      'ubuntu_18.04'
+    end
+
+    def elementary
+      'ubuntu_18.04'
+    end
+
+    attr_reader :id, :version
+  end
+end

--- a/test/test_with_docker.rb
+++ b/test/test_with_docker.rb
@@ -48,11 +48,19 @@ class WithDockerTest < Minitest::Test
   def test_with_archlinux
    test with: 'archlinux'
   end
-  
+
   def test_rockylinux_8
    test with: 'rockylinux_8'
   end
-  
+
+  def test_amazonlinux_2
+   test with: 'amazon_2'
+  end
+
+  def test_amazonlinux_2022
+   test with: 'amazon_2022'
+  end
+
   def test_with_macos
    assert_equal(`bin/wkhtmltopdf --version`.strip, 'wkhtmltopdf 0.12.6 (with patched qt)') if macos?
   end

--- a/test/wkhtmltopdf/linux_os_detector_test.rb
+++ b/test/wkhtmltopdf/linux_os_detector_test.rb
@@ -1,0 +1,54 @@
+require 'minitest/autorun'
+require_relative '../../lib/wkhtmltopdf/linux_os_detector'
+
+module Wkhtmltopdf
+  class LinuxOsDetectorTest < Minitest::Test
+    {
+      ['ubuntu', '16.04'] => 'ubuntu_16.04',
+      ['ubuntu', '16.10'] => 'ubuntu_16.04',
+      ['ubuntu', '17.04'] => 'ubuntu_16.04',
+      ['ubuntu', '17.10'] => 'ubuntu_16.04',
+      ['ubuntu', '18.04'] => 'ubuntu_18.04',
+      ['ubuntu', '18.10'] => 'ubuntu_18.04',
+      ['ubuntu', '19.04'] => 'ubuntu_18.04',
+      ['ubuntu', '19.10'] => 'ubuntu_18.04',
+      ['ubuntu', '20.04'] => 'ubuntu_20.04',
+      ['ubuntu', '20.10'] => 'ubuntu_20.04',
+      ['ubuntu', '21.04'] => 'ubuntu_20.04',
+      ['ubuntu', '21.10'] => 'ubuntu_20.04',
+      ['ubuntu', '22.04'] => 'ubuntu_22.04',
+      ['ubuntu', '22.10'] => 'ubuntu_22.04',
+      ['linuxmint', '18.3'] => 'ubuntu_16.04',
+      ['linuxmint', '19.3'] => 'ubuntu_18.04',
+      ['linuxmint', '20.3'] => 'ubuntu_20.04',
+      ['linuxmint', '21.3'] => 'ubuntu_22.04',
+      ['debian', '9'] => 'debian_9',
+      ['debian', '10'] => 'debian_10',
+      ['amzn', '2018.03'] => 'centos_6',
+      ['amzn', '2'] => 'centos_7',
+      ['amzn', '2022'] => 'centos_7',
+      ['rocky', '8'] => 'centos_8',
+      ['rhel', '8.7'] => 'centos_8',
+      ['arch', 'xxx'] => 'archlinux',
+      ['manjaro', 'xxx'] => 'archlinux',
+      ['zorin', '16.2'] => 'ubuntu_18.04',
+      ['pop', '22.04'] => 'ubuntu_18.04',
+      ['elementary', '7.0'] => 'ubuntu_18.04',
+    }.each do |(id, version), base_os|
+      define_method "test_#{id}_#{version}" do
+        assert_equal base_os, LinuxOsDetector.new(id, version).os
+      end
+    end
+
+    def test_centos_6
+      detector = LinuxOsDetector.new('', '')
+      detector.instance_variable_set(:@extras, {'centos-release' => 'CentOS release 6.10 (Final)'})
+      assert_equal 'centos_6', detector.os
+    end
+
+    def test_unknown_returns_raw_os_and_version
+      assert_equal 'somelinux_10', LinuxOsDetector.new('somelinux', '10').os
+    end
+
+  end
+end


### PR DESCRIPTION
Good day everyone, hope this PR finds you well.

When adding support for additional Linux Mint versions, I found the test suite in the project a bit cumbersome to use. While the docker tests are not only incredibly useful, I would say they are the ultimate source of correctness, they do not cover all the cases, notably, Linux Mint have no official images, and they are slow to execute.

For these reasons, I thought the project could benefit from an easier to test solution, especially seeing how some of the existing test cases are currently failing (ubuntu, arch), also, some of the OS versions currently detected by the code are incorrect (eg: recent versions of deepin, zorin, elementary are based on newer base images, AFAIK).  I've made no attempts at fixing these cases, the aim for the new code was to give identical output to the old one.

I hope this change will make it easier to add support for further distributions.

I also added 2 docker test cases for Amazon linux, one of them is failing with the same error as the arch linux one.