### PR TITLE
Fix a broken archlinux test

### DIFF
--- a/.docker/Dockerfile-archlinux
+++ b/.docker/Dockerfile-archlinux
@@ -2,6 +2,6 @@ FROM archlinux
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN pacman -Sy --noconfirm ruby fontconfig freetype2 libjpeg libpng libxext libxrender
+RUN pacman -Sy --noconfirm ruby fontconfig freetype2 libjpeg libpng libxext libxrender openssl-1.1
 
 CMD /root/wkhtmltopdf_binary_gem/bin/wkhtmltopdf --version


### PR DESCRIPTION
Fix an error that the libssl library could not be found

```
/root/wkhtmltopdf_binary_gem/bin/wkhtmltopdf_archlinux_amd64: error while loading shared libraries: libssl.so.1.1: cannot open shared object file: No such file or directory
```
