### PR TITLE
Add support for tuxedo os

### DIFF
--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -30,7 +30,8 @@ suffix = case RbConfig::CONFIG['host_os']
                                   os.start_with?('linuxmint_20.')
 
            os = 'ubuntu_22.04' if os.start_with?('ubuntu_22.') ||
-                                  os.start_with?('linuxmint_21.')
+                                  os.start_with?('linuxmint_21.') ||
+                                  os.start_with?('tuxedo_22.')
 
            os = 'centos_6' if (os.start_with?('amzn_') && os != 'amzn_2') ||
                               (os.empty? && File.read('/etc/centos-release').start_with?('CentOS release 6'))


### PR DESCRIPTION
Add support for tuxedo os: https://www.tuxedocomputers.com/en/TUXEDO-OS_1.tuxedo

Tuxedo Os 2 is based on ubuntu 22

There are no docker images for so I could not add it to the tests. This exact code is use on my pc as monkey patch to get it working.

Based on error:
`Invalid platform, must be running on Ubuntu 16.04/18.04/20.04/22.04, CentOS 6/7/8, Debian 9/10, Archlinux amd64, or Intel-based Cocoa macOS (missing binary: wkhtmltopdf_tuxedo_22.04_amd64). (RuntimeError)`