### PR TITLE
Fix binary used for Amazon Linux 2023 AMI

### DIFF
--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -45,7 +45,7 @@ suffix = case RbConfig::CONFIG['host_os']
            os = 'ubuntu_22.04' if os.start_with?('ubuntu_22.') ||
                                   os.start_with?('tuxedo_22.')
 
-           os = 'centos_6' if (os.start_with?('amzn_') && os != 'amzn_2' && !os.start_with?('amzn_20')) ||
+           os = 'centos_6' if (os.start_with?('amzn_') && os != 'amzn_2' && os != 'amzn_2023') ||
                               (os.empty? && File.read('/etc/centos-release').start_with?('CentOS release 6'))
 
            os = 'centos_7' if (os.start_with?('amzn_2') && !os.start_with?('amzn_20')) ||
@@ -54,7 +54,7 @@ suffix = case RbConfig::CONFIG['host_os']
            os = 'centos_8' if os.start_with?('rocky_8') ||
                               os.start_with?('rhel_8.') ||
                               os.start_with?('ol_8.') ||
-                              os.start_with?('amzn_20')
+                              os == 'amzn_2023'
 
            os_based_on_debian_9 = os.start_with?('debian_9') ||
                                   os.start_with?('deepin')

--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -45,7 +45,7 @@ suffix = case RbConfig::CONFIG['host_os']
            os = 'ubuntu_22.04' if os.start_with?('ubuntu_22.') ||
                                   os.start_with?('tuxedo_22.')
 
-           os = 'centos_6' if (os.start_with?('amzn_') && os != 'amzn_2') ||
+           os = 'centos_6' if (os.start_with?('amzn_') && os != 'amzn_2' && !os.start_with?('amzn_20')) ||
                               (os.empty? && File.read('/etc/centos-release').start_with?('CentOS release 6'))
 
            os = 'centos_7' if (os.start_with?('amzn_2') && !os.start_with?('amzn_20')) ||
@@ -53,7 +53,8 @@ suffix = case RbConfig::CONFIG['host_os']
 
            os = 'centos_8' if os.start_with?('rocky_8') ||
                               os.start_with?('rhel_8.') ||
-                              os.start_with?('ol_8.')
+                              os.start_with?('ol_8.') ||
+                              os.start_with?('amzn_20')
 
            os_based_on_debian_9 = os.start_with?('debian_9') ||
                                   os.start_with?('deepin')


### PR DESCRIPTION
The current code was written for supporting AWS AMI AL2. 
This causes a bug in Amazon Linux 2023 where it uses CentOS 6 build which is not suitable. This fixes the build to be used for Amazon Linux 2023 to CentOS 8.