### PR TITLE
Add support to ubuntu 24.04

### DIFF
--- a/.docker/Dockerfile-ubuntu_24.04
+++ b/.docker/Dockerfile-ubuntu_24.04
@@ -1,0 +1,8 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update
+RUN apt-get install -y ruby libjpeg8 libxrender1 libfontconfig1
+
+CMD /root/wkhtmltopdf_binary_gem/bin/wkhtmltopdf --version

--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -38,11 +38,12 @@ suffix = case RbConfig::CONFIG['host_os']
 
            os = 'ubuntu_20.04' if os.start_with?('ubuntu_20.') ||
                                   os.start_with?('linuxmint_20.')
-           
+
 	         os = 'ubuntu_21.10' if os.start_with?('ubuntu_21.') ||
                                   os.start_with?('linuxmint_21.')
 
            os = 'ubuntu_22.04' if os.start_with?('ubuntu_22.') ||
+                                  os.start_with?('ubuntu_24.') ||
                                   os.start_with?('tuxedo_22.')
 
            os = 'centos_6' if (os.start_with?('amzn_') && os != 'amzn_2') ||

--- a/test/test_with_docker.rb
+++ b/test/test_with_docker.rb
@@ -57,6 +57,10 @@ class WithDockerTest < Minitest::Test
    test_on_x86 with: 'ubuntu_22.04'
   end
 
+  def test_with_ubuntu_24
+    test_on_x86 with: 'ubuntu_24.04'
+   end
+
   def test_with_archlinux
     test_on_x86 with: 'archlinux'
   end


### PR DESCRIPTION
Closes to https://github.com/zakird/wkhtmltopdf_binary_gem/issues/175

As mentioned by @unixmonkey, there's no official build for ubuntu24.04 on https://wkhtmltopdf.org/downloads.html.  
We could use the same binary used for `ubuntu_22.04`;  

This pull request includes updates to support Ubuntu 24.04 in the Docker setup and associated tests. The most important changes include adding a new Dockerfile for Ubuntu 24.04 and updating the test suite to include a test for Ubuntu 24.04.

### Docker support for Ubuntu 24.04:

* [`.docker/Dockerfile-ubuntu_24.04`](diffhunk://#diff-eae690bf8262f978a076b03c46580108402b6392d45744588b92584ec0a749f8R1-R8): Added a new Dockerfile for Ubuntu 24.04, setting up the environment and installing necessary packages.

### Test suite updates:

* [`test/test_with_docker.rb`](diffhunk://#diff-87080b560a27041113dd2e708bdc05d4f9ef6e3cd66fbbad588f24fda5607a38R60-R63): Added a new test method `test_with_ubuntu_24` to test the setup on Ubuntu 24.04.
