### PR TITLE
Add support to ubuntu 22.04 and 24.04 in arm64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ bin/wkhtmltopdf_ubuntu_20.04_amd64
 bin/wkhtmltopdf_ubuntu_20.04_arm64
 bin/wkhtmltopdf_ubuntu_21.10_amd64
 bin/wkhtmltopdf_ubuntu_22.04_amd64
+bin/wkhtmltopdf_ubuntu_22.04_arm64

--- a/docker-compose-arm.yml
+++ b/docker-compose-arm.yml
@@ -28,3 +28,17 @@ services:
       dockerfile: .docker/Dockerfile-debian_12_arm
     volumes:
       - .:/root/wkhtmltopdf_binary_gem
+
+  ubuntu_22.04:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile-ubuntu_22.04
+    volumes:
+      - .:/root/wkhtmltopdf_binary_gem
+
+  ubuntu_24.04:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile-ubuntu_24.04
+    volumes:
+      - .:/root/wkhtmltopdf_binary_gem

--- a/test/test_with_docker.rb
+++ b/test/test_with_docker.rb
@@ -54,12 +54,12 @@ class WithDockerTest < Minitest::Test
   end
 
   def test_with_ubuntu_22
-   test_on_x86 with: 'ubuntu_22.04'
+   test_on_x86_and_arm with: 'ubuntu_22.04'
   end
 
   def test_with_ubuntu_24
-    test_on_x86 with: 'ubuntu_24.04'
-   end
+    test_on_x86_and_arm with: 'ubuntu_24.04'
+  end
 
   def test_with_archlinux
     test_on_x86 with: 'archlinux'


### PR DESCRIPTION
The binary is the same for Ubuntu 22.04 and 24.04

> [!IMPORTANT]
> To check the binary is the same as the one from https://wkhtmltopdf.org/downloads.html before using and/or merging this branch, run the following:
> ```
> $ curl -L https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_arm64.deb > wkhtmltox_0.12.6.1-2.jammy_arm64.deb
> $ dpkg -x wkhtmltox_0.12.6.1-2.jammy_arm64.deb wkhtmltox/
> $ git clone -b add-ubuntu-24-04-arm --single-branch --depth 1 https://github.com/chileung-b4b/wkhtmltopdf_binary_gem.git
> $ gunzip -c ./wkhtmltopdf_binary_gem/bin/wkhtmltopdf_ubuntu_22.04_arm64.gz | sha256sum -
> 00fbba5e1ee392776c2978b45503c07af34c42086c842b31dc9d7a76d52fcf29  -
> $ sha256sum wkhtmltox/usr/local/bin/wkhtmltopdf
> 00fbba5e1ee392776c2978b45503c07af34c42086c842b31dc9d7a76d52fcf29  wkhtmltox/usr/local/bin/wkhtmltopdf
> ```