### PR TITLE
Add 64-bit ARM support for Ubuntu 22.04 and 24.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ bin/wkhtmltopdf_ubuntu_20.04_amd64
 bin/wkhtmltopdf_ubuntu_20.04_arm64
 bin/wkhtmltopdf_ubuntu_21.10_amd64
 bin/wkhtmltopdf_ubuntu_22.04_amd64
+bin/wkhtmltopdf_ubuntu_22.04_arm64

--- a/docker-compose-arm.yml
+++ b/docker-compose-arm.yml
@@ -28,3 +28,17 @@ services:
       dockerfile: .docker/Dockerfile-debian_12_arm
     volumes:
       - .:/root/wkhtmltopdf_binary_gem
+
+  ubuntu_22.04:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile-ubuntu_22.04
+    volumes:
+      - .:/root/wkhtmltopdf_binary_gem
+
+  ubuntu_24.04:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile-ubuntu_24.04
+    volumes:
+      - .:/root/wkhtmltopdf_binary_gem

--- a/test/test_with_docker.rb
+++ b/test/test_with_docker.rb
@@ -54,12 +54,12 @@ class WithDockerTest < Minitest::Test
   end
 
   def test_with_ubuntu_22
-   test_on_x86 with: 'ubuntu_22.04'
+   test_on_x86_and_arm with: 'ubuntu_22.04'
   end
 
   def test_with_ubuntu_24
-    test_on_x86 with: 'ubuntu_24.04'
-   end
+    test_on_x86_and_arm with: 'ubuntu_24.04'
+  end
 
   def test_with_archlinux
     test_on_x86 with: 'archlinux'


### PR DESCRIPTION
Custom fork to test out https://github.com/zakird/wkhtmltopdf_binary_gem/pull/181.