### PR TITLE
Update wkhtmltopdf to support Debian 13

### DIFF
--- a/.docker/Dockerfile-debian_13
+++ b/.docker/Dockerfile-debian_13
@@ -1,0 +1,8 @@
+FROM debian:13
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update
+RUN apt-get install -y ruby libjpeg62-turbo libpng16-16 libxrender1 libfontconfig1 libxext6
+
+CMD /root/wkhtmltopdf_binary_gem/bin/wkhtmltopdf --version

--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -72,6 +72,8 @@ suffix = case RbConfig::CONFIG['host_os']
 
            os = 'debian_12' if !os_based_on_debian_9 && os.start_with?('debian_12')
 
+           os = 'debian_12' if !os_based_on_debian_9 && os.start_with?('debian_13')
+
            os = 'archlinux' if os.start_with?('arch_') ||
                                os.start_with?('manjaro_')
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '3'
 
 services:
-
   ubuntu_16.04:
     build:
       context: .
@@ -55,6 +54,13 @@ services:
     build:
       context: .
       dockerfile: .docker/Dockerfile-debian_12
+    volumes:
+      - .:/root/wkhtmltopdf_binary_gem
+
+  debian_13:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile-debian_13
     volumes:
       - .:/root/wkhtmltopdf_binary_gem
 

--- a/test/test_with_docker.rb
+++ b/test/test_with_docker.rb
@@ -41,6 +41,10 @@ class WithDockerTest < Minitest::Test
     test_on_x86_and_arm with: 'debian_12'
   end
 
+  def test_debian_13
+    test_on_x86 with: 'debian_13'
+  end
+
   def test_with_ubuntu_16
     test_on_x86 with: 'ubuntu_16.04'
   end


### PR DESCRIPTION
[Issue 193](https://github.com/zakird/wkhtmltopdf_binary_gem/issues/193)

Add Support for Debian 13.